### PR TITLE
Clarify usage

### DIFF
--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -1,6 +1,6 @@
 # Git & GitHub conventions
 
-These conventions apply to open-source, internal and client projects.
+These conventions apply to our open-source, internal and client projects.
 
 ## Basic setup
 


### PR DESCRIPTION
I'd prefer to drop every reference to `Hyper` or `company` where we can use `we`, `us`, etc. Feels more homely.
