### PR TITLE
Document direnv

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -9,3 +9,8 @@ We use [label](https://github.com/jgorset/label) to label the gems in our Gemfil
 ## Heroku
 
 We use [heroku-deploy](https://github.com/hyperoslo/heroku-deploy) as the best way to send our latest version to Heroku.
+
+## Direnv
+
+We configure our Ruby on Rails applications with environment variables. A lot of environment variables. We use
+[direnv](https://github.com/zimbatm/direnv/) to keep them in check.


### PR DESCRIPTION
We currently use either [figaro](https://github.com/laserlemon/figaro) or [dotenv](https://github.com/bkeepers/dotenv) to manage our environment variables. These are good gems, but one could argue that adding them to your Gemfile is not ideal.

I've been using [direnv](https://github.com/zimbatm/direnv/) for various purposes (like adding `./bin` to `$PATH`) and it occurred to me that this is probably a less obtrusive way of configuring my application, too.

What do you guys think?
