### PR TITLE
Remove reference to "bro code"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ![Banner](https://raw.githubusercontent.com/hyperoslo/playbook/master/assets/images/banner_v2.png)
 
-> “The bro code of Hyper” – [@sindrenm](http://github.com/sindrenm)
-
 ## Index
 
 1. [Git & GitHub Conventions](https://github.com/hyperoslo/playbook/blob/master/GIT_AND_GITHUB.md)


### PR DESCRIPTION
In light of stuff like "Gamer gate" and other sexist things on the Internet, Hyper should maybe not use words like this. It might come of as sexist. We should encourage woman to work at Hyper, and the use of phrases like this might be misinterpreted.