### PR TITLE
Add initial workflow for freelancers and production companies

### DIFF
--- a/FREELANCERS_AND_PRODUCTION_COMPANIES.md
+++ b/FREELANCERS_AND_PRODUCTION_COMPANIES.md
@@ -1,0 +1,93 @@
+# Freelancers and productions companies
+
+As a freelancer or production company for Hyper we expect you to follow our guidelines for
+production. Underneath you’ll find and overview of how we work and what we expect from you.
+
+  We hold your opinion in high regard and want to here what you have to bring to the table. But to
+make our work the most effective, especially down the line, we have a set of guidelines.  
+
+## Day to day workflow 
+
+### Design
+
+All our work involve working closely with the whole team at Hyper. But for technology the closest
+ties are to the designers. Their experience with both visual and interaction design paired with
+your knowledge about technology is our edge in developing apps.
+
+They use [Zeplin](https://zeplin.io/) to deliver the designs. This way we don't have to dig trough
+Sketch or Photoshop file to get the correct font-size. Zeplin can be opened in the app on Mac or on
+the web.
+
+### Code
+
+*Regarding code*, we would like to invite you to work in our GitHub. There you’ll get access to the
+repos you need. We will have a internal developer helping you get access and providing access to
+other services you need. 
+
+We would like you to follow our style guides and best practice.
+
+- [Git and GitHub](https://github.com/hyperoslo/playbook/blob/master/GIT_AND_GITHUB.md)
+- [Workflow](https://github.com/hyperoslo/playbook/blob/master/WORKFLOW.md)
+- [Code styles](https://github.com/hyperoslo/playbook/blob/master/CODE_STYLE.md)
+
+Make sure you read up on this before starting a project. If you have any input or questions be sure
+to ask, we are here to help and love to discuss code. 
+
+When working we would prefer pull requests with well written commits and documented work. This way
+we can follow along and make sure we understand what is being done and make it easier for us to
+maintain. 
+
+## Documentation
+
+Think about your readme as your apps resume or CV, it should give a great overview of what it
+contains and how it works. The readme should be structured and easy to navigate. 
+
+The readme should consist of tree parts: 
+1. How to run the app and where to find it. It should be easy to understand how to set up the app
+from the documentation in the readme. It should also be easy to figure out where the app is hosted,
+where to access, staging and production and where the admin is located and how that works. 
+2. Give and overview of the functionality. If your app consists of some special functionality,
+contact with third party APIs or any other elements that are not immediately clear make sure to
+especially document them. 
+3. Links and documentation of any third party services. Especially if they are not regular Hyper
+services.
+
+## Credentials and third party apps
+
+### Third party apps
+
+Be sure to register all third party apps to a Hyper account. Ask the Hyper developer responsible for
+your project to help if you need to. This is to make sure we don't have to chase you down after the
+project to get access to parts of the project.
+
+ This includes things like; Facebook apps, API keys, third party accounts, hosting or helper
+services, and so on.
+
+### Credentials
+
+ Be sure to make strong passwords for any admin or outwards facing infrastructure. No usernames and
+passwords should ever be stored in the GitHub repo.  We use ENV variables from
+[Heroku](https://heroku.com) to handle this.
+
+## General workflow 
+
+### Slack
+
+We will invite you to our Slack where you’ll get access to projects channels to communicate with
+your team and potentially the client. 
+
+### Onsite and remote
+
+We would like you to visit our office at least two times a week and preferably more. This way you
+can have the closest work with the rest of the team.
+
+If you choose to work remotely you are free to do so, just let your team know when and where you are
+and what you are working with. Communication is key when working remote and its important to be
+overly clear in your communication.  Read up on our
+[remote guidelines](https://github.com/hyperoslo/playbook/blob/master/WORKING_REMOTE.md).
+
+### Rest of the team
+
+Besides the designers and developers you’ll work with project managers, creatives and advisors. We
+are all part of a big team and are here to help each other deliver the best possible product. Both
+good and bad news should be shared in your team to make the ride as smooth as possible.


### PR DESCRIPTION
This is up for discussion (and proof reading). We are trying to establish a way to work best with freelancers and third party production companies.

So that if we dont have capacity to take on work or there is work we dont want to do in tech we can have a common ground to start from.

We already have strong guidelines that we should enforce to make, for example, support easier.

What do you guys think. 